### PR TITLE
fixing tiny build errors

### DIFF
--- a/Language/C/Parser/Lexer.x
+++ b/Language/C/Parser/Lexer.x
@@ -1,6 +1,7 @@
 {
 {-# OPTIONS -w #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
 
 -- Copyright (c) 2006-2011
 --         The President and Fellows of Harvard College.

--- a/Language/C/Parser/Parser.y
+++ b/Language/C/Parser/Parser.y
@@ -1,5 +1,6 @@
 {
 {-# OPTIONS -w #-}
+{-# LANGUAGE BangPatterns #-}
 
 -- Copyright (c) 2006-2011
 --         The President and Fellows of Harvard College.


### PR DESCRIPTION
I get these slightly puzzling build errors (shown below) when trying to build language-c-quote.  Puzzling, because language-c-quote builds and installs cleanly on another machine with identical versions of ghc
(7.4.1) and alex (3.0.1).

I'm not sure what causes it, but adding "{-# LANGUAGE BangPatterns #-}" line to Language/C/Parser/Parser.y and Language/C/Parser/Lexer.x makes these errors go away.

Build error, from Lexer.x:

```
$ cabal build
Building language-c-quote-0.3.1.0...
Preprocessing library language-c-quote-0.3.1.0...
unused terminals: 4
[ 1 of 15] Compiling Language.C.Syntax ( Language/C/Syntax.hs, dist/build/Language/C/Syntax.o )
[ 2 of 15] Compiling Language.C.Parser.Tokens ( Language/C/Parser/Tokens.hs, dist/build/Language/C/Parser/Tokens.o )
[ 3 of 15] Compiling Language.C.Parser.Monad ( Language/C/Parser/Monad.hs, dist/build/Language/C/Parser/Monad.o )
[ 4 of 15] Compiling Language.C.Parser.Lexer ( dist/build/Language/C/Parser/Lexer.hs, dist/build/Language/C/Parser/Lexer.o )

dist/build/Language/C/Parser/Lexer.hs:634:17:
    Illegal bang-pattern (use -XBangPatterns):
    ! (base)
```

Build error from Parser.y, after fixing Lexer.x:

```
$ cabal build
Building language-c-quote-0.3.1.0...
Preprocessing library language-c-quote-0.3.1.0...
[ 4 of 15] Compiling Language.C.Parser.Lexer ( dist/build/Language/C/Parser/Lexer.hs, dist/build/Language/C/Parser/Lexer.o )
[ 5 of 15] Compiling Language.C.Pretty ( Language/C/Pretty.hs, dist/build/Language/C/Pretty.o )
[ 6 of 15] Compiling Language.C.Parser.Parser ( dist/build/Language/C/Parser/Parser.hs, dist/build/Language/C/Parser/Parser.o )

templates/GenericTemplate.hs:112:44:
    Illegal bang-pattern (use -XBangPatterns):
    ! (new_state)
```

These changes don't seem to affect anything else.
