### PR TITLE
Unit tests for desired comment statement behavior

### DIFF
--- a/tests/unit/Main.hs
+++ b/tests/unit/Main.hs
@@ -321,7 +321,6 @@ statementCommentTests = testGroup "Statement comments"
         [cstms|
         a = 1;
         /* c style comment */
-        ;
         |]
 
         @?= [ assign_a_equals_one
@@ -332,7 +331,6 @@ statementCommentTests = testGroup "Statement comments"
         [cstms|
         a = 1;
         // c++ style comment
-        ;
         |]
 
         @?= [ assign_a_equals_one
@@ -342,7 +340,6 @@ statementCommentTests = testGroup "Statement comments"
     test_antiquote_comment =
         [cstms|
         $comment:("/* antiquote comment */")
-        ;
         |]
 
         @?= [ C.Comment "/* antiquote comment */" (C.Exp Nothing noLoc) noLoc


### PR DESCRIPTION
0ebd246 shows working unit tests for all three ways to express a comment (//, /**/, and $comment).
8868b10 shows desired behavior - comments stand alone as a statement and do not require an (empty) statement afterwards. (This commit will fail at compile time with a parse error.)
