### PR TITLE
Add `parseBlockItems` to `Parser`

### DIFF
--- a/Language/C/Parser/Parser.y
+++ b/Language/C/Parser/Parser.y
@@ -305,6 +305,7 @@ import qualified Language.C.Syntax as C
 %name parseStm        statement
 %name parseStms       statement_list
 %name parseBlockItem  block_item
+%name parseBlockItems block_item_list
 
 %name parseUnit       translation_unit
 %name parseFunc       function_definition

--- a/Language/C/Quote.hs
+++ b/Language/C/Quote.hs
@@ -44,6 +44,8 @@
 -- [@citem@] Block item, of type @'BlockItem'@. A block item is either a
 -- declaration or a statement.
 --
+-- [@citems@] A list of block items, of type @['BlockItem'].
+--
 -- [@cfun@] Function definition, of type @'Func'@.
 --
 -- [@cinit@] Initializer, of type @'Initializer'@.

--- a/Language/C/Quote/C.hs
+++ b/Language/C/Quote/C.hs
@@ -22,6 +22,7 @@ module Language.C.Quote.C (
     cstm,
     cstms,
     citem,
+    citems,
     cunit,
     cfun
   ) where
@@ -38,7 +39,7 @@ typenames :: [String]
 typenames = []
 
 cdecl, cedecl, cenum, cexp, cfun, cinit, cparam, cparams, csdecl, cstm, cstms :: QuasiQuoter
-citem, cty, cunit :: QuasiQuoter
+citem, citems, cty, cunit :: QuasiQuoter
 cdecl   = quasiquote exts typenames P.parseDecl
 cedecl  = quasiquote exts typenames P.parseEdecl
 cenum   = quasiquote exts typenames P.parseEnum
@@ -51,5 +52,6 @@ csdecl  = quasiquote exts typenames P.parseStructDecl
 cstm    = quasiquote exts typenames P.parseStm
 cstms   = quasiquote exts typenames P.parseStms
 citem   = quasiquote exts typenames P.parseBlockItem
+citems  = quasiquote exts typenames P.parseBlockItems
 cty     = quasiquote exts typenames P.parseType
 cunit   = quasiquote exts typenames P.parseUnit

--- a/Language/C/Quote/CUDA.hs
+++ b/Language/C/Quote/CUDA.hs
@@ -22,6 +22,7 @@ module Language.C.Quote.CUDA (
     cstm,
     cstms,
     citem,
+    citems,
     cunit,
     cfun
   ) where
@@ -46,7 +47,7 @@ typeN :: Int -> String -> [String]
 typeN k typename = [typename ++ show n | n <- [1..k]]
 
 cdecl, cedecl, cenum, cexp, cfun, cinit, cparam, cparams, csdecl, cstm, cstms :: QuasiQuoter
-citem, cty, cunit :: QuasiQuoter
+citem, citems, cty, cunit :: QuasiQuoter
 cdecl   = quasiquote exts typenames P.parseDecl
 cedecl  = quasiquote exts typenames P.parseEdecl
 cenum   = quasiquote exts typenames P.parseEnum
@@ -59,5 +60,6 @@ csdecl  = quasiquote exts typenames P.parseStructDecl
 cstm    = quasiquote exts typenames P.parseStm
 cstms   = quasiquote exts typenames P.parseStms
 citem   = quasiquote exts typenames P.parseBlockItem
+citems  = quasiquote exts typenames P.parseBlockItems
 cty     = quasiquote exts typenames P.parseType
 cunit   = quasiquote exts typenames P.parseUnit

--- a/Language/C/Quote/GCC.hs
+++ b/Language/C/Quote/GCC.hs
@@ -22,6 +22,7 @@ module Language.C.Quote.GCC (
     cstm,
     cstms,
     citem,
+    citems,
     cunit,
     cfun
   ) where
@@ -38,7 +39,7 @@ typenames :: [String]
 typenames = []
 
 cdecl, cedecl, cenum, cexp, cfun, cinit, cparam, cparams, csdecl, cstm, cstms :: QuasiQuoter
-citem, cty, cunit :: QuasiQuoter
+citem, citems, cty, cunit :: QuasiQuoter
 cdecl   = quasiquote exts typenames P.parseDecl
 cedecl  = quasiquote exts typenames P.parseEdecl
 cenum   = quasiquote exts typenames P.parseEnum
@@ -51,5 +52,6 @@ csdecl  = quasiquote exts typenames P.parseStructDecl
 cstm    = quasiquote exts typenames P.parseStm
 cstms   = quasiquote exts typenames P.parseStms
 citem   = quasiquote exts typenames P.parseBlockItem
+citems  = quasiquote exts typenames P.parseBlockItems
 cty     = quasiquote exts typenames P.parseType
 cunit   = quasiquote exts typenames P.parseUnit

--- a/Language/C/Quote/ObjC.hs
+++ b/Language/C/Quote/ObjC.hs
@@ -26,6 +26,7 @@ module Language.C.Quote.ObjC (
     cstm,
     cstms,
     citem,
+    citems,
     cunit,
     cfun,
     objcprop,
@@ -70,7 +71,7 @@ objcLit :: a -> ObjCLit a
 objcLit = ObjCLit
 
 cdecl, cedecl, cenum, cexp, cfun, cinit, cparam, cparams, csdecl, cstm, cstms :: QuasiQuoter
-citem, cty, cunit :: QuasiQuoter
+citem, citems, cty, cunit :: QuasiQuoter
 cdecl   = quasiquote exts typenames P.parseDecl
 cedecl  = quasiquote exts typenames P.parseEdecl
 cenum   = quasiquote exts typenames P.parseEnum
@@ -83,6 +84,7 @@ csdecl  = quasiquote exts typenames P.parseStructDecl
 cstm    = quasiquote exts typenames P.parseStm
 cstms   = quasiquote exts typenames P.parseStms
 citem   = quasiquote exts typenames P.parseBlockItem
+citems  = quasiquote exts typenames P.parseBlockItems
 cty     = quasiquote exts typenames P.parseType
 cunit   = quasiquote exts typenames P.parseUnit
 

--- a/Language/C/Quote/OpenCL.hs
+++ b/Language/C/Quote/OpenCL.hs
@@ -21,6 +21,7 @@ module Language.C.Quote.OpenCL (
     cstm,
     cstms,
     citem,
+    citems,
     cunit,
     cfun
   ) where
@@ -50,7 +51,7 @@ typeN :: String -> [String]
 typeN typename = [typename ++ show n | n <- [2, 3, 4, 8, 16 :: Integer]]
 
 cdecl, cedecl, cenum, cexp, cfun, cinit, cparam, cparams, csdecl, cstm, cstms :: QuasiQuoter
-citem, cty, cunit :: QuasiQuoter
+citem, citems, cty, cunit :: QuasiQuoter
 cdecl   = quasiquote exts typenames P.parseDecl
 cedecl  = quasiquote exts typenames P.parseEdecl
 cenum   = quasiquote exts typenames P.parseEnum
@@ -63,5 +64,6 @@ csdecl  = quasiquote exts typenames P.parseStructDecl
 cstm    = quasiquote exts typenames P.parseStm
 cstms   = quasiquote exts typenames P.parseStms
 citem   = quasiquote exts typenames P.parseBlockItem
+citems  = quasiquote exts typenames P.parseBlockItems
 cty     = quasiquote exts typenames P.parseType
 cunit   = quasiquote exts typenames P.parseUnit


### PR DESCRIPTION
Maybe I'm missing something, but I think this ought to be here, given the presence of the `items` antiquote.