### PR TITLE
No haskell-src-meta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@
 
 # The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
 env:
- - CABALVER=1.16 GHCVER=7.4.2
- - CABALVER=1.18 GHCVER=7.6.3
- - CABALVER=1.18 GHCVER=7.8.3
- - CABALVER=1.22 GHCVER=7.10.2
+ - CABALVER=1.16 GHCVER=7.4.2  FLAGS=""
+ - CABALVER=1.18 GHCVER=7.6.3  FLAGS=""
+ - CABALVER=1.18 GHCVER=7.8.3  FLAGS=""
+ - CABALVER=1.22 GHCVER=7.10.2 FLAGS=""
+ - CABALVER=1.22 GHCVER=7.10.2 FLAGS="-f -full-haskell-antiquotes"
  - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 # Note: the distinction between `before_install` and `install` is not important.
@@ -32,7 +33,7 @@ install:
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks -v2 $FLAGS  # -v2 provides useful information for debugging
  - travis_wait cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
  - cabal check

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - travis_wait cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - travis_wait cabal install --only-dependencies --enable-tests --enable-benchmarks $FLAGS
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
 # If there are no other `.tar.gz` files in `dist`, this can be even simpler:
 # `cabal install --force-reinstalls dist/*-*.tar.gz`
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+   (cd dist && cabal install $FLAGS --force-reinstalls "$SRC_TGZ")
 
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - `IsString` instances for `Id` and `StringLit` data types.
+- Conditionally use the lightweight haskell-exp-parser instead of haskell-src-meta.
 
 ### Fixed
 - #55 Comments at the top of a block before a declaration.

--- a/Language/C/Quote/Base.hs
+++ b/Language/C/Quote/Base.hs
@@ -26,7 +26,11 @@ import Data.Data (Data(..))
 import Data.Generics (extQ)
 import Data.Loc
 import Data.Typeable (Typeable(..))
-import Language.Haskell.Meta (parseExp, parsePat)
+#ifdef FULL_HASKELL_ANTIQUOTES
+import Language.Haskell.Meta (parseExp,parsePat)
+#else
+import Language.Haskell.ParseExp (parseExp,parsePat)
+#endif
 import Language.Haskell.TH
 #if MIN_VERSION_template_haskell(2,7,0)
 import Language.Haskell.TH.Quote (QuasiQuoter(..),

--- a/language-c-quote.cabal
+++ b/language-c-quote.cabal
@@ -107,6 +107,9 @@ test-suite unit
     test-framework       >= 0.8 && < 0.9,
     test-framework-hunit >= 0.3 && < 0.4
 
+  if flag(full-haskell-antiquotes)
+    cpp-options: -DFULL_HASKELL_ANTIQUOTES
+
 source-repository head
   type:     git
   location: git://github.com/mainland/language-c-quote.git

--- a/language-c-quote.cabal
+++ b/language-c-quote.cabal
@@ -25,6 +25,7 @@ build-type: Custom
 extra-source-files:
   Language/C/Syntax-instances.hs
   tests/unit/Objc.hs
+  tests/unit/MainCPP.hs
 
 flag full-haskell-antiquotes
   description: Support full Haskell expressions/patterns in antiquotes. This

--- a/language-c-quote.cabal
+++ b/language-c-quote.cabal
@@ -26,6 +26,12 @@ extra-source-files:
   Language/C/Syntax-instances.hs
   tests/unit/Objc.hs
 
+flag full-haskell-antiquotes
+  description: Support full Haskell expressions/patterns in antiquotes. This
+               adds a dependency on haskell-src-meta, which increases
+               compilation time.
+  default:     True
+
 library
   default-language: Haskell98
 
@@ -37,13 +43,17 @@ library
     exception-mtl          >= 0.3   && < 0.5,
     exception-transformers >= 0.3   && < 0.5,
     filepath               >= 1.2   && < 1.5,
-    haskell-src-meta       >= 0.4   && < 0.7,
     mainland-pretty        >= 0.4   && < 0.5,
     mtl                    >= 2.0   && < 3,
     srcloc                 >= 0.4   && < 0.6,
     syb                    >= 0.3   && < 0.7,
     symbol                 >= 0.1   && < 0.3,
     template-haskell
+
+  if flag(full-haskell-antiquotes)
+    build-depends: haskell-src-meta   >= 0.4 && < 0.7
+  else
+    build-depends: haskell-exp-parser >= 0.1 && < 0.2
 
   if impl(ghc < 7.4)
     build-tools:
@@ -74,8 +84,11 @@ library
     Language.C.Syntax
 
   include-dirs: .
-  
+
   ghc-options: -Wall
+
+  if flag(full-haskell-antiquotes)
+    cpp-options: -DFULL_HASKELL_ANTIQUOTES
 
 test-suite unit
   type:             exitcode-stdio-1.0

--- a/tests/unit/Main.hs
+++ b/tests/unit/Main.hs
@@ -12,6 +12,7 @@ import Control.Exception (SomeException)
 import Language.C.Quote.C
 import qualified Language.C.Syntax as C
 import qualified Language.C.Parser as P
+import MainCPP
 import Numeric (showHex)
 import Objc (objcTests)
 import System.Exit (exitFailure, exitSuccess)
@@ -65,15 +66,15 @@ constantTests = testGroup "Constants"
           @?= C.Const (C.LongLongIntConst "0x10ULL" C.Unsigned 16 noLoc) noLoc
 
 constantAntiquotationsTests :: Test
-constantAntiquotationsTests = testGroup "Constant antiquotations"
+constantAntiquotationsTests = testGroup "Constant antiquotations" $
     [ testCase "int antiquotes" test_int
     , testCase "hex Const antiquote" test_hexconst
     , testCase "unsigned hex Const antiquote" test_hexconst_u
     , testCase "float antiquotes" test_float
     , testCase "char antiquote" test_char
     , testCase "string antiquote" test_string
-    , testCase "unsigned long antiquote of Haskell expression" test_int_hsexp
     ]
+    ++ testCase_test_int_hsexp
   where
     test_int :: Assertion
     test_int =
@@ -122,10 +123,6 @@ constantAntiquotationsTests = testGroup "Constant antiquotations"
         [cexp|$string:hello|] @?= [cexp|"Hello, world\n"|]
       where
         hello = "Hello, world\n"
-
-    test_int_hsexp :: Assertion
-    test_int_hsexp =
-        [cexp|$ulint:(13 - 2*5)|] @?= [cexp|3UL|]
 
 cQuotationTests :: Test
 cQuotationTests = testGroup "C quotations"

--- a/tests/unit/MainCPP.hs
+++ b/tests/unit/MainCPP.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- This module is needed because it's not possible to turn on CPP in Main.hs.
+
+module MainCPP where
+
+import Test.Framework.Providers.HUnit
+import Test.HUnit (Assertion, (@?=))
+
+import Language.C.Quote.C
+
+testCase_test_int_hsexp =
+#ifdef FULL_HASKELL_ANTIQUOTES
+    [testCase "unsigned long antiquote of Haskell expression" test_int_hsexp]
+  where
+    test_int_hsexp :: Assertion
+    test_int_hsexp =
+        [cexp|$ulint:(13 - 2*5)|] @?= [cexp|3UL|]
+#else
+    []
+#endif
+

--- a/tests/unit/MainCPP.hs
+++ b/tests/unit/MainCPP.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 -- This module is needed because it's not possible to turn on CPP in Main.hs.
+-- We need CPP because this test case doesn't work without FULL_HASKELL_ANTIQUOTES
+-- turned on. (The simpler Haskell parser doesn't support infix operators.)
 
 module MainCPP where
 


### PR DESCRIPTION
When compiling on my machine in a clean sandbox with

    cabal install language-c-quote -f-full-haskell-antiquotes

compilation time shrinks from 5:30 to 2 minutes. The size of the sandbox is reduced by roughly the same factor.

The gain on Travis is not as large unfortunately: 13 mins instead of 19 mins for the last commit:

  * <https://travis-ci.org/emilaxelsson/language-c-quote/builds/88384860>

(It seems installation of language-c-quote itself takes very long on GHC 7.10 compared to earlier GHCs. Maybe Travis runs out of memory?)

I pulled out one test case to a module `MainCPP.hs` so that it's only used when `full-haskell-antiquotes` is on. Another option would have been to rewrite the test case to something without infix operators. But I guess in general you will anyway want to have tests that only pass with `full-haskell-antiquotes`.