### PR TITLE
Explicitly import Data.Char.ord.

### DIFF
--- a/Language/C/Parser/Lexer.x
+++ b/Language/C/Parser/Lexer.x
@@ -31,6 +31,7 @@ import Data.Char (isAlphaNum,
                   isLower,
                   isSpace,
                   chr,
+                  ord,
                   toLower)
 import Data.List (foldl',
                   intersperse,


### PR DESCRIPTION
This fixes compatibility with newer versions of Alex.