### PR TITLE
language-c-quote.cabal: add missing CUDA to tarball

### DIFF
--- a/language-c-quote.cabal
+++ b/language-c-quote.cabal
@@ -24,8 +24,6 @@ build-type: Custom
 
 extra-source-files:
   Language/C/Syntax-instances.hs
-  tests/unit/Objc.hs
-  tests/unit/MainCPP.hs
 
 flag full-haskell-antiquotes
   description: Support full Haskell expressions/patterns in antiquotes. This
@@ -95,6 +93,11 @@ test-suite unit
   type:             exitcode-stdio-1.0
   hs-source-dirs:   tests/unit
   main-is:          Main.hs
+  other-modules:
+    CUDA
+    Objc
+    MainCPP
+
   default-language: Haskell98
 
   build-depends:


### PR DESCRIPTION
Test building failed as:

  Preprocessing test suite 'unit' for language-c-quote-0.11.5...

  tests/unit/Main.hs:18:8:
    Could not find module ‘CUDA’
    Use -v to see a list of the files searched for.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>