### PR TITLE
ObjC needs blocks and GCC extensions

### DIFF
--- a/Language/C/Quote/ObjC.hs
+++ b/Language/C/Quote/ObjC.hs
@@ -48,7 +48,7 @@ import Language.C.Quote.Base (ToIdent(..), ToConst(..), ToExp(..), quasiquote)
 import Language.Haskell.TH.Quote (QuasiQuoter)
 
 exts :: [C.Extensions]
-exts = [C.ObjC]
+exts = [C.ObjC, C.Blocks, C.Gcc]
 
 typenames :: [String]
 typenames = ["id", "instancetype"]


### PR DESCRIPTION
Current Objective-C compilers automatically include blocks and GCC extensions, such as one-line comments. We ought to mirror that.