### PR TITLE
Add case labels with ranges as a GCC extension

### DIFF
--- a/Language/C/Pretty.hs
+++ b/Language/C/Pretty.hs
@@ -585,6 +585,10 @@ instance Pretty Stm where
         srcloc sloc <>
         indent (-2) (line <> text "case" <+> ppr e <> colon) </> ppr stm
 
+    ppr (CaseRange e1 e2 stm sloc) =
+        srcloc sloc <>
+        indent (-2) (line <> text "case" <+> ppr e1 <+> text "..." <+> ppr e2 <> colon) </> ppr stm
+
     ppr (Default stm sloc) =
         srcloc sloc <>
         indent (-2) (line <> text "default" <> colon) </> ppr stm

--- a/Language/C/Syntax-instances.hs
+++ b/Language/C/Syntax-instances.hs
@@ -149,6 +149,7 @@ instance Located Definition where
 instance Located Stm where
   locOf (Label _ _ _ l) = locOf l
   locOf (Case _ _ l) = locOf l
+  locOf (CaseRange _ _ _ l) = locOf l
   locOf (Default _ l) = locOf l
   locOf (Exp _ l) = locOf l
   locOf (Block _ l) = locOf l
@@ -461,6 +462,7 @@ instance Relocatable Definition where
 instance Relocatable Stm where
   reloc l (Label x0 x1 x2 _) = (Label x0 x1 x2 (fromLoc l))
   reloc l (Case x0 x1 _) = (Case x0 x1 (fromLoc l))
+  reloc l (CaseRange x0 x1 x2 _) = (CaseRange x0 x1 x2 (fromLoc l))
   reloc l (Default x0 _) = (Default x0 (fromLoc l))
   reloc l (Exp x0 _) = (Exp x0 (fromLoc l))
   reloc l (Block x0 _) = (Block x0 (fromLoc l))

--- a/Language/C/Syntax.hs
+++ b/Language/C/Syntax.hs
@@ -238,6 +238,7 @@ data Definition  =  FuncDef    Func      !SrcLoc
 
 data Stm  = Label Id [Attr] Stm !SrcLoc
           | Case Exp Stm !SrcLoc
+          | CaseRange Exp Exp Stm !SrcLoc
           | Default Stm !SrcLoc
           | Exp (Maybe Exp) !SrcLoc
           | Block [BlockItem] !SrcLoc

--- a/tests/unit/GCC.hs
+++ b/tests/unit/GCC.hs
@@ -6,13 +6,14 @@ module GCC (
 
 import Test.Framework
 import Test.Framework.Providers.HUnit
-import Test.HUnit (Assertion, (@?=))
+import Test.HUnit (Assertion, assert, (@?=))
 
 import qualified Data.ByteString.Char8 as B
 import Data.Char (isSpace)
 import Data.Loc (SrcLoc, noLoc, startPos)
 import Control.Exception (SomeException)
 import Language.C.Quote.GCC
+import Language.C.Smart ()
 import qualified Language.C.Syntax as C
 import qualified Language.C.Parser as P
 import Text.PrettyPrint.Mainland
@@ -23,6 +24,8 @@ gccTests = testGroup "GCC attribute quotations"
     [ testCase "attr antiquote" test_attr
     , testCase "attrs antiquote" test_attrs
     , testCase "attrs antiquote pretty" test_attr_p
+    , testCase "case ranges quote" test_case_ranges
+    , testCase "case ranges pretty" test_case_ranges_p
     ]
   where
     test_attr :: Assertion
@@ -47,3 +50,12 @@ gccTests = testGroup "GCC attribute quotations"
     test_attr_p :: Assertion
     test_attr_p =
       pretty 80 (ppr [cattr|section(".sram2")|]) @?= "section(\".sram2\")"
+
+    test_case_ranges :: Assertion
+    test_case_ranges = assert $ case [cstm| case 10 ... 20: ; |] of
+      C.CaseRange 10 20 (C.Exp Nothing _) _ -> True
+      _ -> False
+
+    test_case_ranges_p :: Assertion
+    test_case_ranges_p =
+      pretty 80 (ppr [cstm| case 10 ... 20: ; |]) @?= "\ncase 10 ... 20:\n;"


### PR DESCRIPTION
Closes #87.

I did my best to update the relevant parts, including parsing and pretty-printing, and to make sure it's only enabled with the GCC extensions.

Please me know if there's anything else that needs to be updated for this change.